### PR TITLE
fix accreditation and its relationship with other tables

### DIFF
--- a/backend/futureu/src/main/java/edu/cit/futureu/controller/AccreditationController.java
+++ b/backend/futureu/src/main/java/edu/cit/futureu/controller/AccreditationController.java
@@ -3,6 +3,8 @@ package edu.cit.futureu.controller;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,9 +17,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import edu.cit.futureu.entity.AccreditationEntity;
+import edu.cit.futureu.entity.SchoolEntity;
 import edu.cit.futureu.entity.SchoolProgramEntity;
 import edu.cit.futureu.service.AccreditationService;
 import edu.cit.futureu.service.SchoolProgramService;
+import edu.cit.futureu.service.SchoolService;
 
 @RestController
 @RequestMapping(method=RequestMethod.GET, path="/api/accreditation")
@@ -25,6 +29,9 @@ public class AccreditationController {
     
     @Autowired
     private AccreditationService accreditationService;
+    
+    @Autowired
+    private SchoolService schoolService;
     
     @Autowired
     private SchoolProgramService schoolProgramService;
@@ -46,21 +53,21 @@ public class AccreditationController {
         return accreditationService.getAllAccreditations();
     }
     
-    // Get accreditation by ID
+    // Get by ID
     @GetMapping("/getAccreditation/{accredId}")
     public AccreditationEntity getAccreditationById(@PathVariable int accredId) {
         return accreditationService.getAccreditationById(accredId)
                 .orElse(null);
     }
     
-    // Get accreditations by school program ID
-    @GetMapping("/getAccreditationsBySchoolProgram/{schoolProgramId}")
-    public List<AccreditationEntity> getAccreditationsBySchoolProgram(@PathVariable int schoolProgramId) {
-        SchoolProgramEntity schoolProgram = schoolProgramService.getSchoolProgramById(schoolProgramId).orElse(null);
-        if (schoolProgram != null) {
-            return accreditationService.getAccreditationsBySchoolProgram(schoolProgram);
+    // Get accreditations by school
+    @GetMapping("/getAccreditationsBySchool/{schoolId}")
+    public List<AccreditationEntity> getAccreditationsBySchool(@PathVariable int schoolId) {
+        SchoolEntity school = schoolService.getSchoolById(schoolId).orElse(null);
+        if (school != null) {
+            return accreditationService.getAccreditationsBySchool(school);
         }
-        return List.of(); // Return empty list if school program not found
+        return List.of(); // Return empty list if school not found
     }
     
     // Search accreditations by title
@@ -68,28 +75,30 @@ public class AccreditationController {
     public List<AccreditationEntity> searchAccreditations(@RequestParam String title) {
         return accreditationService.searchAccreditationsByTitle(title);
     }
-    
+
     // Get accreditations by recognition status
     @GetMapping("/getByRecognitionStatus")
-    public List<AccreditationEntity> getAccreditationsByRecognitionStatus(@RequestParam String status) {
+    public List<AccreditationEntity> getByRecognitionStatus(@RequestParam String status) {
         return accreditationService.getAccreditationsByRecognitionStatus(status);
     }
     
     // Get accreditations by accrediting body
     @GetMapping("/getByAccreditingBody")
-    public List<AccreditationEntity> getAccreditationsByAccreditingBody(@RequestParam String body) {
+    public List<AccreditationEntity> getByAccreditingBody(@RequestParam String body) {
         return accreditationService.getAccreditationsByAccreditingBody(body);
     }
     
     // Get accreditations by accreditation level
     @GetMapping("/getByAccreditationLevel")
-    public List<AccreditationEntity> getAccreditationsByAccreditationLevel(@RequestParam String level) {
+    public List<AccreditationEntity> getByAccreditationLevel(@RequestParam String level) {
         return accreditationService.getAccreditationsByAccreditationLevel(level);
     }
     
     // UPDATE
     @PutMapping("/putAccreditationDetails")
-    public AccreditationEntity putAccreditationDetails(@RequestParam int accredId, @RequestBody AccreditationEntity newAccreditationDetails) {
+    public AccreditationEntity putAccreditationDetails(
+            @RequestParam int accredId, 
+            @RequestBody AccreditationEntity newAccreditationDetails) {
         newAccreditationDetails.setAccredId(accredId);
         return accreditationService.updateAccreditation(newAccreditationDetails);
     }
@@ -98,6 +107,58 @@ public class AccreditationController {
     @DeleteMapping("/deleteAccreditationDetails/{accredId}")
     public String deleteAccreditation(@PathVariable int accredId) {
         boolean deleted = accreditationService.deleteAccreditation(accredId);
-        return deleted ? "Accreditation with ID " + accredId + " successfully deleted" : "Accreditation with ID " + accredId + " not found";
+        return deleted ? 
+                "Accreditation with ID " + accredId + " successfully deleted" : 
+                "Accreditation with ID " + accredId + " not found";
+    }
+    
+    // NEW ENDPOINT: Assign accreditation to school programs
+    @PostMapping("/assignToSchoolPrograms")
+    public ResponseEntity<?> assignAccreditationToSchoolPrograms(
+            @RequestParam int accredId,
+            @RequestParam int schoolId,
+            @RequestParam(required = false) Integer programId) {
+        
+        try {
+            // Get the accreditation
+            AccreditationEntity accreditation = accreditationService.getAccreditationById(accredId)
+                    .orElseThrow(() -> new Exception("Accreditation not found with ID: " + accredId));
+            
+            // Get the school
+            SchoolEntity school = schoolService.getSchoolById(schoolId)
+                    .orElseThrow(() -> new Exception("School not found with ID: " + schoolId));
+            
+            // Get the school programs
+            List<SchoolProgramEntity> programs;
+            
+            if (programId != null) {
+                // Only get a specific program
+                SchoolProgramEntity specific = schoolProgramService.getSchoolProgramById(programId)
+                        .orElse(null);
+                
+                if (specific != null && specific.getSchool().getSchoolId() == schoolId) {
+                    programs = List.of(specific);
+                } else {
+                    return ResponseEntity.badRequest().body("Invalid program ID or program doesn't belong to the specified school");
+                }
+            } else {
+                // Get all programs for this school
+                programs = schoolProgramService.getSchoolProgramsBySchool(school);
+            }
+            
+            // Update each program with the accreditation
+            int updatedCount = 0;
+            for (SchoolProgramEntity program : programs) {
+                program.setAccreditation(accreditation);
+                schoolProgramService.updateSchoolProgram(program);
+                updatedCount++;
+            }
+            
+            return ResponseEntity.ok("Successfully assigned accreditation to " + updatedCount + " program(s)");
+            
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("Error assigning accreditation: " + e.getMessage());
+        }
     }
 }

--- a/backend/futureu/src/main/java/edu/cit/futureu/controller/SchoolProgramController.java
+++ b/backend/futureu/src/main/java/edu/cit/futureu/controller/SchoolProgramController.java
@@ -1,6 +1,8 @@
+
 package edu.cit.futureu.controller;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -68,7 +70,20 @@ public class SchoolProgramController {
     public List<SchoolProgramEntity> getSchoolProgramsBySchool(@PathVariable int schoolId) {
         SchoolEntity school = schoolService.getSchoolById(schoolId).orElse(null);
         if (school != null) {
-            return schoolProgramService.getSchoolProgramsBySchool(school);
+            List<SchoolProgramEntity> schoolPrograms = schoolProgramService.getSchoolProgramsBySchool(school);
+            
+            // Ensure all related entities are eagerly loaded and accessible
+            return schoolPrograms.stream()
+                .peek(sp -> {
+                    if (sp.getAccreditation() != null) {
+                        // Touch the accreditation to force eager loading
+                        AccreditationEntity accred = sp.getAccreditation();
+                        accred.getAccreditationLevel();
+                        accred.getAccreditingBody();
+                        accred.getRecognitionStatus();
+                    }
+                })
+                .collect(Collectors.toList());
         }
         return List.of(); // Return empty list if school not found
     }

--- a/backend/futureu/src/main/java/edu/cit/futureu/entity/AccreditationEntity.java
+++ b/backend/futureu/src/main/java/edu/cit/futureu/entity/AccreditationEntity.java
@@ -1,7 +1,5 @@
 package edu.cit.futureu.entity;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
-
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -17,12 +15,11 @@ public class AccreditationEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int accredId;
-
-    // Many-to-one relationship with SchoolProgram
+    
+    // Many-to-one relationship with School
     @ManyToOne
-    @JoinColumn(name = "school_program_id")
-    @JsonBackReference
-    private SchoolProgramEntity schoolProgram;
+    @JoinColumn(name = "school_id")
+    private SchoolEntity school;
 
     private String title;
     private String description;
@@ -41,13 +38,13 @@ public class AccreditationEntity {
     public void setAccredId(int accredId) {
         this.accredId = accredId;
     }
-
-    public SchoolProgramEntity getSchoolProgram() {
-        return schoolProgram;
+    
+    public SchoolEntity getSchool() {
+        return school;
     }
-
-    public void setSchoolProgram(SchoolProgramEntity schoolProgram) {
-        this.schoolProgram = schoolProgram;
+    
+    public void setSchool(SchoolEntity school) {
+        this.school = school;
     }
 
     public String getTitle() {

--- a/backend/futureu/src/main/java/edu/cit/futureu/entity/SchoolEntity.java
+++ b/backend/futureu/src/main/java/edu/cit/futureu/entity/SchoolEntity.java
@@ -49,6 +49,11 @@ public class SchoolEntity {
     @JsonIgnore
     @OneToMany(mappedBy = "school", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SchoolProgramEntity> schoolPrograms;
+    
+    // One-to-many to Accreditation
+    @JsonIgnore
+    @OneToMany(mappedBy = "school", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<AccreditationEntity> accreditations;
 
     public SchoolEntity() {}
 
@@ -123,6 +128,14 @@ public class SchoolEntity {
     public void setSchoolPrograms(List<SchoolProgramEntity> schoolPrograms) {
         this.schoolPrograms = schoolPrograms;
     }
+    
+    public List<AccreditationEntity> getAccreditations() {
+        return accreditations;
+    }
+    
+    public void setAccreditations(List<AccreditationEntity> accreditations) {
+        this.accreditations = accreditations;
+    }
 
     public String getSchoolWebsiteUrl() {
         return schoolWebsiteUrl;
@@ -140,3 +153,4 @@ public class SchoolEntity {
        this.averageRating = averageRating;
     }
 }
+

--- a/backend/futureu/src/main/java/edu/cit/futureu/entity/SchoolProgramEntity.java
+++ b/backend/futureu/src/main/java/edu/cit/futureu/entity/SchoolProgramEntity.java
@@ -1,7 +1,5 @@
 package edu.cit.futureu.entity;
 
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 
 import jakarta.persistence.Entity;
@@ -10,7 +8,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
 @Entity
@@ -31,10 +28,10 @@ public class SchoolProgramEntity {
     @JoinColumn(name = "programId", nullable = false)
     private ProgramEntity program;
 
-    // One-to-many relationship with Accreditation
-    @OneToMany(mappedBy = "schoolProgram")
-    @JsonManagedReference
-    private List<AccreditationEntity> accreditations;
+    // Many-to-one relationship with Accreditation
+    @ManyToOne
+    @JoinColumn(name = "accred_id")
+    private AccreditationEntity accreditation;
 
     public SchoolProgramEntity() {
 
@@ -64,11 +61,11 @@ public class SchoolProgramEntity {
         this.program = program;
     }
 
-    public List<AccreditationEntity> getAccreditations() {
-        return accreditations;
+    public AccreditationEntity getAccreditation() {
+        return accreditation;
     }
 
-    public void setAccreditations(List<AccreditationEntity> accreditations) {
-        this.accreditations = accreditations;
+    public void setAccreditation(AccreditationEntity accreditation) {
+        this.accreditation = accreditation;
     }
 }

--- a/backend/futureu/src/main/java/edu/cit/futureu/repository/AccreditationRepository.java
+++ b/backend/futureu/src/main/java/edu/cit/futureu/repository/AccreditationRepository.java
@@ -1,17 +1,25 @@
+
 package edu.cit.futureu.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import edu.cit.futureu.entity.AccreditationEntity;
-import edu.cit.futureu.entity.SchoolProgramEntity;
+import edu.cit.futureu.entity.SchoolEntity;
 
 @Repository
 public interface AccreditationRepository extends JpaRepository<AccreditationEntity, Integer> {
-    // Find accreditations by schoolProgram
-    List<AccreditationEntity> findBySchoolProgram(SchoolProgramEntity schoolProgram);
+    // Find accreditations by school
+    List<AccreditationEntity> findBySchool(SchoolEntity school);
+    
+    // Custom query to find accreditation by its ID
+    @Query("SELECT a FROM AccreditationEntity a WHERE a.accredId = :accredId")
+    Optional<AccreditationEntity> findByAccredId(@Param("accredId") Integer accredId);
     
     // Find accreditations by title
     List<AccreditationEntity> findByTitleContainingIgnoreCase(String title);

--- a/backend/futureu/src/main/java/edu/cit/futureu/repository/SchoolProgramRepository.java
+++ b/backend/futureu/src/main/java/edu/cit/futureu/repository/SchoolProgramRepository.java
@@ -1,3 +1,4 @@
+
 package edu.cit.futureu.repository;
 
 import java.util.List;
@@ -5,6 +6,7 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import edu.cit.futureu.entity.AccreditationEntity;
 import edu.cit.futureu.entity.ProgramEntity;
 import edu.cit.futureu.entity.SchoolEntity;
 import edu.cit.futureu.entity.SchoolProgramEntity;
@@ -19,4 +21,10 @@ public interface SchoolProgramRepository extends JpaRepository<SchoolProgramEnti
     
     // Find specific school-program combination
     SchoolProgramEntity findBySchoolAndProgram(SchoolEntity school, ProgramEntity program);
+    
+    // Find school programs by accreditation
+    List<SchoolProgramEntity> findByAccreditation(AccreditationEntity accreditation);
+    
+    // Find school programs by accreditation ID
+    List<SchoolProgramEntity> findByAccreditation_AccredId(Integer accredId);
 }

--- a/frontend/futureu-capstone/src/services/accreditationService.js
+++ b/frontend/futureu-capstone/src/services/accreditationService.js
@@ -1,3 +1,4 @@
+
 import apiClient from './api';
 import authService from './authService';
 
@@ -190,11 +191,11 @@ class AccreditationService {
             // Process school programs and their accreditations
             for (const schoolProgram of schoolPrograms) {
               if (schoolProgram.program) {
-                // Add the program with its accreditations (which are now directly attached)
+                // Add the program with its accreditation (singular, not a list)
                 allPrograms.push({
                   program: schoolProgram.program,
                   schoolProgram: schoolProgram,
-                  accreditations: schoolProgram.accreditations || []
+                  accreditation: schoolProgram.accreditation
                 });
               }
             }
@@ -230,52 +231,44 @@ class AccreditationService {
                 programCategories[category] = [];
               }
               
-              // Find the best accreditation for this program
-              let bestAccreditation = null;
-              
-              // If we have accreditations directly from schoolProgram
-              if (item.accreditations && item.accreditations.length > 0) {
-                // Find the highest level accreditation
-                bestAccreditation = item.accreditations.reduce((best, current) => {
-                  const bestLevel = best ? this.parseAccreditationLevel(best.accreditationLevel) : 0;
-                  const currentLevel = this.parseAccreditationLevel(current.accreditationLevel);
-                  return currentLevel > bestLevel ? current : best;
-                }, null);
-              }
-              
-              // Debug log
-              if (bestAccreditation) {
-                console.log(`Accreditation found for ${program.programName}:`, {
-                  accredId: bestAccreditation.accredId,
-                  accreditationLevel: bestAccreditation.accreditationLevel,
-                  accreditingBody: bestAccreditation.accreditingBody
-                });
-              }
-              
-              // Determine accreditation status 
+              // Get accreditation data from the single accreditation property
               let accreditationStatus = 'Not Accredited';
-              let accreditingBody = 'N/A';
+              let accreditingBody = '-';
               let recognitionStatus = null;
               let level = 0;
               
-              if (bestAccreditation) {
+              // Check if program has accreditation data
+              if (item.accreditation) {
+                const accreditation = item.accreditation;
+                
                 // Set accreditation status and level
-                if (bestAccreditation.accreditationLevel) {
-                  accreditationStatus = `${bestAccreditation.accreditationLevel} Accredited`;
-                  level = this.parseAccreditationLevel(bestAccreditation.accreditationLevel);
+                if (accreditation.accreditationLevel) {
+                  accreditationStatus = `${accreditation.accreditationLevel} Accredited`;
+                  level = this.parseAccreditationLevel(accreditation.accreditationLevel);
                 }
                 
                 // Set accrediting body
-                if (bestAccreditation.accreditingBody) {
-                  accreditingBody = bestAccreditation.accreditingBody;
+                if (accreditation.accreditingBody) {
+                  accreditingBody = accreditation.accreditingBody;
                 }
                 
-                // Set recognition status
-                if (bestAccreditation.recognitionStatus && bestAccreditation.recognitionStatus !== 'None') {
-                  recognitionStatus = bestAccreditation.recognitionStatus;
+                // Set recognition status (COE, COD)
+                if (accreditation.recognitionStatus && accreditation.recognitionStatus !== 'None') {
+                  recognitionStatus = accreditation.recognitionStatus;
                 }
               }
               
+              // Debug log
+              if (item.accreditation) {
+                console.log(`Accreditation found for ${program.programName}:`, {
+                  accredId: item.accreditation.accredId,
+                  level: level,
+                  accreditingBody: accreditingBody,
+                  recognitionStatus: recognitionStatus
+                });
+              }
+              
+              // Create program object
               programCategories[category].push({
                 name: program.programName,
                 description: program.description,
@@ -639,3 +632,4 @@ class AccreditationService {
 // Create an instance of the AccreditationService
 const accreditationService = new AccreditationService();
 export default accreditationService; 
+

--- a/frontend/futureu-capstone/src/services/adminAccreditationService.js
+++ b/frontend/futureu-capstone/src/services/adminAccreditationService.js
@@ -1,3 +1,4 @@
+
 import apiClient from './api';
 
 /**
@@ -78,6 +79,28 @@ class AdminAccreditationService {
   }
 
   /**
+   * Assign an accreditation to school program(s)
+   * @param {number} accredId - The accreditation ID
+   * @param {number} schoolId - The school ID
+   * @param {number} [programId] - Optional program ID (if null, assigns to all programs of the school)
+   * @returns {Promise<string>} - Success message
+   */
+  async assignAccreditationToPrograms(accredId, schoolId, programId = null) {
+    try {
+      const params = { accredId, schoolId };
+      if (programId) {
+        params.programId = programId;
+      }
+      
+      const response = await apiClient.post('/accreditation/assignToSchoolPrograms', null, { params });
+      return response.data;
+    } catch (error) {
+      this.handleError(error, 'Assigning accreditation to programs');
+      throw error;
+    }
+  }
+
+  /**
    * Search accreditations by title
    * @param {string} title - The title to search for
    * @returns {Promise<Array>} - List of matching accreditations
@@ -143,3 +166,5 @@ class AdminAccreditationService {
 }
 
 export default new AdminAccreditationService();
+
+


### PR DESCRIPTION
- Updated the AccreditationEntity to include the relationship with School
- Updated the SchoolEntity to include the relationship with AccreditationEntity
- Added a new method findBySchool to fetch accreditations by school
- Added a method findByAccredId to find an accreditation by its ID
- Modified the service's getAccreditationsBySchoolProgram method 
- Removed the findBySchoolProgram method from the repository
- access schoolProgram.accreditation instead of expecting an array of accreditations
- updated the CRUD_Accreditation.jsx file to include the new fields for accreditation(accrediting_body, accreditation_level, recognition_status)
-Added  Dropdown options for each field:
      Accreditation Level: Level I, Level II, Level III, Level IV
      Accrediting Body: PACUCOA, PAASCU, AACCUP, DOST-SEI
      Recognition Status: COE (Center of Excellence), COD (Center of Development)
- Updated the table to display these new fields in additional columns
- When admin adds a new record in the accreditation crud, the input fields needed are the title, school, accreditation level, accredtitng body, recognition status and description. After admin selects a school, it will automatically show a drop down of all the programs offered by that school so that the admin can directly assign the accreditation to a specific program by that school

![CRUD_Accre](https://github.com/user-attachments/assets/f9d0b533-3cc2-474a-b724-9846a3ef3d2e)

