### PR TITLE
fix-localstorage-v1

### DIFF
--- a/frontend/futureu-capstone/src/components/Counselor/CounselorLogin.jsx
+++ b/frontend/futureu-capstone/src/components/Counselor/CounselorLogin.jsx
@@ -5,10 +5,8 @@ import authService from '../../services/authService';
 import { Mail, Lock, LogIn, AlertCircle, Heart, Eye, EyeOff } from 'lucide-react';
 
 const customSignout = () => {
-  localStorage.removeItem('token');
-  localStorage.removeItem('user');
-  localStorage.removeItem('current_assessment');
-  localStorage.removeItem('assessment_progress');
+  // Reuse centralized cleanup to ensure full parity with student/admin logout
+  try { authService.clearClientData(); } catch {}
   // No automatic redirect
 };
 

--- a/frontend/futureu-capstone/src/components/Navigation.jsx
+++ b/frontend/futureu-capstone/src/components/Navigation.jsx
@@ -81,7 +81,7 @@ const Navigation = () => {
     setTooltipPinned(false);
   }, [location.pathname]);
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
     const userId = authService.getCurrentUserId();
     if (userId) {
       Object.keys(localStorage).forEach(key => {
@@ -90,11 +90,10 @@ const Navigation = () => {
         }
       });
     }
-    authService.signout();
+    await authService.signout();
     setIsAuthenticated(false);
     setCurrentUser(null);
     setShowDropdown(false);
-    navigate('/');
   };
 
   const handleProfileClick = (e) => {

--- a/frontend/futureu-capstone/src/contexts/ProfileContext.jsx
+++ b/frontend/futureu-capstone/src/contexts/ProfileContext.jsx
@@ -146,6 +146,9 @@ export const ProfileProvider = ({ children }) => {
   // Save profile to localStorage cache
   const saveToCache = (userId, profile, pictureUrl = null) => {
     try {
+      // Do not write to cache when not authenticated (e.g., during logout teardown)
+      if (!authService.isAuthenticated()) return;
+
       const cacheKeys = getCacheKeys(userId);
       
       localStorage.setItem(cacheKeys.profile, JSON.stringify(profile));

--- a/frontend/futureu-capstone/src/services/authService.js
+++ b/frontend/futureu-capstone/src/services/authService.js
@@ -47,6 +47,9 @@ class AuthService {
    * Sign out user and clear all cookies
    */
   async signout() {
+    // Pre-clear to avoid race with components writing on unmount
+    this.clearClientData();
+
     try {
       await apiClient.post('/auth/signout', {}, {
         withCredentials: true
@@ -56,11 +59,11 @@ class AuthService {
       // Continue with logout even if server request fails
     }
     
-    // Clear any remaining client-side data
+    // Post-clear to ensure nothing was re-written by teardown effects
     this.clearClientData();
     
     // Redirect to login page
-    window.location.href = '/login';
+    window.location.replace('/login');
   }
 
   /**
@@ -72,6 +75,54 @@ class AuthService {
     localStorage.removeItem('assessment_progress');
     localStorage.removeItem('assessment_answers');
     localStorage.removeItem('user_preferences');
+
+    // Remove cached profile data stored per-user
+    try {
+      const prefixesToClear = [
+        'futureu_profile_',
+        'futureu_profile_picture_',
+        'futureu_profile_picture_blob_',
+        'futureu_profile_timestamp_',
+        // assessment related
+        'assessment_start_time_',
+        // recommendations related
+        'futureu_recommendations_',
+        'futureu_program_recommendations_',
+        'futureu_comprehensive_recommendations_'
+      ];
+
+      const exactKeysToClear = [
+        'admin_dashboard_data',
+        'futureu_pending_deletion',
+        'futureu_refresh_testimonials',
+        'academicExplorerWelcomeSeen'
+      ];
+
+      // Clear exact keys if present
+      exactKeysToClear.forEach((key) => {
+        try { localStorage.removeItem(key); } catch {}
+      });
+
+      // Clear keys by prefix
+      Object.keys(localStorage).forEach((key) => {
+        if (prefixesToClear.some((prefix) => key.startsWith(prefix))) {
+          try { localStorage.removeItem(key); } catch {}
+        }
+      });
+    } catch (e) {
+      console.error('Error clearing localStorage caches:', e);
+    }
+
+    // Clear any session-scoped hints/prompts
+    try {
+      Object.keys(sessionStorage).forEach((key) => {
+        if (key.startsWith('futureu_profile_prompt_shown_')) {
+          try { sessionStorage.removeItem(key); } catch {}
+        }
+      });
+    } catch (e) {
+      console.error('Error clearing sessionStorage caches:', e);
+    }
   }
 
   /**


### PR DESCRIPTION
Robust logout storage cleanup and prevent re-caching on teardown

- Clear profile caches and admin keys on logout:

  - futureu_profile_, futureu_profile_timestamp, futureu_profile_picture, futureu_profile_picture_blob*
  - admin_dashboard_data, futureu_pending_deletion, futureu_refresh_testimonials
  - assessment_start_time_, futureurecommendations*
  - academicExplorerWelcomeSeen

- Pre- and post-clear around signout request; redirect via location.replace to avoid back-nav artifacts
- Student logout: await signout and remove extra navigate('/') to prevent remount race
- Counselor customSignout now uses centralized clearClientData
- ProfileContext: guard saveToCache to no-op when !isAuthenticated to stop re-writing caches during logout teardown